### PR TITLE
Fix syntax on contraint validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ In one migration:
 
 ```elixir
 def change do
-  create constraint("products", :price_must_be_positive, check: "price > 0"), validate: false
+  create constraint("products", :price_must_be_positive, check: "price > 0", validate: false)
   # Setting validate: false will prevent a full table scan, and therefore
   # commits immediately.
 end
@@ -436,7 +436,7 @@ In the first migration:
 ```elixir
 # Deployment 1
 def change do
-  create constraint("products", :active_not_null, check: "active IS NOT NULL"), validate: false
+  create constraint("products", :active_not_null, check: "active IS NOT NULL", validate: false)
 end
 ```
 


### PR DESCRIPTION
Thanks for this _incredibly_ useful guide. ☺️ This corrects a small syntax error that briefly confused me.

Relevant docs:

- [Ecto.Migration.constraint/3](https://hexdocs.pm/ecto_sql/Ecto.Migration.html#constraint/3)
- [Ecto.Migration.create/1](https://hexdocs.pm/ecto_sql/3.7.2/Ecto.Migration.html#create/1)
- [Ecto.Migration.create/2 macro](https://hexdocs.pm/ecto_sql/3.7.2/Ecto.Migration.html#create/2)